### PR TITLE
Fix module import

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I hope in the future I can get it to:
 - [ ] Convert a musical note to semitone difference from root
 - [ ] Convert a MIDI note to a musical note
 - [ ] And any other conversions in between
-- [ ] Be available as an ES Module
+- [x] Be available as an ES Module
 
 # Install & usage
 Install with either
@@ -28,7 +28,7 @@ const { frequency } = require("@liamjcooper/keys.js");
 ```
 or...
 ```js
-const frequency = require("@liamjcooper/keys.js/frequency");
+const frequency = require("@liamjcooper/keys.js/dist/frequency");
 ```
 
 # Documentation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@liamjcooper/keys.js",
   "version": "1.0.2",
   "description": "A library suited to help with musical notes, frequency and MIDI.",
-  "main": "src/index.js",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "test": "mocha",
     "build": "tsc"

--- a/src/frequency.ts
+++ b/src/frequency.ts
@@ -1,9 +1,7 @@
-function forSemitoneFromRoot(semitonesFromRoot: number) {
+export function forSemitoneFromRoot(semitonesFromRoot: number) {
   return 440 * Math.pow(2, semitonesFromRoot / 12);
 }
 
-function forMidiNote(midiNote: number) {
+export function forMidiNote(midiNote: number) {
   return 440 * Math.pow(2, (midiNote - 69) / 12);
 }
-
-module.exports = { forSemitoneFromRoot, forMidiNote };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,0 @@
-const frequency = require("./frequency");
-
-module.exports = { frequency };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * as frequency from "./frequency"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,25 +1,17 @@
 {
   "compilerOptions": {
-    "incremental": true,
-
     "target": "ESNext",
 
     "module": "commonjs",
-    "rootDir": ".",
     "baseUrl": ".",
-    "paths": {
-      "*": [
-        "*",
-        "src/*"
-      ]
-    },
+    "rootDir": "./src",
 
     "declaration": true,
     "declarationMap": true,
-    "outDir": "dist",
+    "outDir": "./dist",
     "sourceMap": true,
-    "sourceRoot": "src",
 
+    "allowJs": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
 
@@ -36,5 +28,5 @@
   },
 
   "exclude": ["node_modules", "dist"],
-  "include": ["src", "test", "*"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
Fixes #3 - updated `package.json` entrypoint to reflect newly built `index.js` in the `dist` directory as well as type definition entrypoint. Now when importing in another codebase, there should be no warning about type defs.

Also simplified the TS config a bit and updated the README.